### PR TITLE
Added function to get a normalize path component

### DIFF
--- a/surlparser.cpp
+++ b/surlparser.cpp
@@ -2,6 +2,9 @@
 #include <string>
 #include "surlparser.h"
 
+SUrlParser::SUrlParser(const char *uri) {
+    parse(uri);
+}
 
 bool SUrlParser::parse(const char *uri) {
     m_folders.clear();
@@ -44,7 +47,7 @@ bool SUrlParser::parse(const char *uri) {
             } else if ( *c == '\0' && s.length() > 0 ) {
                 if ( t == Type::value ) {
                     m_keysvalues[last_param] = s;
-                } else if ( t == Type::folder ) {
+                } else if ( t == Type::folder || t == Type::begin ) {
                     m_folders.push_back(s);
                 } else if ( t == Type::param ) {
                     m_keysvalues[s] = "";
@@ -68,10 +71,6 @@ bool SUrlParser::parse(const char *uri) {
     return true;
 }
 
-KeyValueMap_t &SUrlParser::args() {
-    return m_keysvalues;
-}
-
 void SUrlParser::print(char splitter) {
     std::cout << std::endl;
     std::cout << "Total " << m_folders.size() << " folders, see below (if any)" << std::endl;
@@ -82,5 +81,22 @@ void SUrlParser::print(char splitter) {
         std::cout << "Key:[" << n.first << "] Value: [" << n.second << "]" << splitter;
     }
     std::cout << std::endl;
+}
+
+/**
+ * Extract only the path component from the passed URI 
+ * and normalized it.
+ * Ex. //one/two////three///
+ * becomes
+ *  /one/two/three
+ */
+string SUrlParser::path() {
+    string s = "/"; // set up the beginning slash
+    for ( string &f : m_folders) {
+        s += f;
+        s += "/";
+    }
+    s.pop_back(); // deleting last letter, that is slash '/'
+    return string(s);
 }
 

--- a/surlparser.h
+++ b/surlparser.h
@@ -15,10 +15,12 @@ class SUrlParser {
         KeyValueMap_t m_keysvalues;
         Folder_t m_folders;
     public:
+        SUrlParser() {};
+        SUrlParser(const char *url);
         bool parse(const char *url);
         Folder_t &paths() { return m_folders; };
         KeyValueMap_t &params() { return m_keysvalues; };
-        KeyValueMap_t &args();
+        string path();
         void print(char splitter='\n');
 };
 

--- a/test.cpp
+++ b/test.cpp
@@ -1,19 +1,62 @@
 #include <string>
+#include <iostream>
 #include <cassert>
 #include "surlparser.h"
 
 using namespace std;
 
+void testall();
+void testpath();
+bool test(const char *path, const char *compare_to);
+
+bool test(const char *path, const char *compare_to);
+
 int main(int argc, char **argv) {
+    testall();
+    testpath();
+    return 0;
+}
 
-    SUrlParser m;
+void testpath() {
 
-    if ( argc > 1 ) {
-        m.parse(argv[1]);
-        m.print();
-        return 0;
+    assert( test( "/test", "/test" ));
+    assert( test( "///test", "/test" ));
+    assert( test( "///test//////", "/test" ));
+    assert( test( "test", "/test" ));
+    assert( test( "test", "/test" ));
+    assert( test( "test/", "/test" ));
+    assert( test( "test////", "/test" ));
+
+    assert( test( "/device/ping", "/device/ping" ));
+    assert( test( "///device/////ping", "/device/ping" ));
+    assert( test( "device/ping////", "/device/ping" ));
+    assert( test( "/device/ping", "/device/ping" ));
+    assert( test( "/device/ping", "/device/ping" ));
+
+    assert( test( "/device/ping?youre=mine", "/device/ping" ));
+    assert( test( "device/ping?youre=mine", "/device/ping" ));
+    assert( test( "device/ping/?youre=mine", "/device/ping" ));
+    assert( test( "device/ping/?youre=mine&me=isyoure", "/device/ping" ));
+    assert( test( "////device/////ping//////?youre=mine&and&I=youers", "/device/ping" ));
+}
+
+bool test(const char *path, const char *compare_to) {
+    bool result = false;
+    SUrlParser p;
+    p.parse(path);
+    std::cout << "Test path: [" << path << "] ... ";
+    string s = p.path();
+    if ( s == string(compare_to) ) {
+        std::cout << "GOOD, " << s << std::endl;
+        result = true;
+    } else {
+        std::cout << "BAD, " << s << std::endl << std::endl;
     }
+    return result;
+}
 
+void testall() {
+    SUrlParser m;
     m.parse("/one/two/three");
     assert( m.paths().size() == 3 && m.params().size() == 0 );
     m.parse("//one/two/three");
@@ -86,7 +129,5 @@ int main(int argc, char **argv) {
     m.parse("one/two/three/////");
     assert( m.paths().size() == 3 && m.params().size() == 0 );
 
-
-    return 0;
 }
 


### PR DESCRIPTION
Removed an excessive args() function, which is replaced by the params().
Added the path() function which returns a normalized path component of passed URI. Normalized means, if you pass the URI like this ////foo////bar/////?arg1=...., it returns /foo/bar only and strips the path separator.